### PR TITLE
fix: add emergency pause to withdraw-sbtc

### DIFF
--- a/contracts/yield-aggregator.clar
+++ b/contracts/yield-aggregator.clar
@@ -26,6 +26,7 @@
 (define-constant ERR_DEPOSIT_FAILED (err u105))
 (define-constant ERR_WITHDRAWAL_FAILED (err u106))
 (define-constant ERR_YIELD_CALCULATION_FAILED (err u107))
+(define-constant ERR_CONTRACT_PAUSED (err u108))
 
 ;; data vars
 (define-data-var contract-initialized bool false)
@@ -75,7 +76,7 @@
     (current-user-deposit (default-to u0 (map-get? user-deposits tx-sender)))
   )
     (asserts! (var-get contract-initialized) ERR_NOT_INITIALIZED)
-    (asserts! (not (var-get emergency-pause)) ERR_UNAUTHORIZED)
+    (asserts! (not (var-get emergency-pause)) ERR_CONTRACT_PAUSED)
     (asserts! (> amount u0) ERR_INVALID_AMOUNT)
     (asserts! (>= current-balance amount) ERR_INSUFFICIENT_BALANCE)
     (asserts! (<= (+ current-user-deposit amount) (var-get max-deposit-per-user)) ERR_INVALID_AMOUNT)
@@ -110,7 +111,7 @@
     (total-available (+ user-deposit user-yield))
   )
     (asserts! (var-get contract-initialized) ERR_NOT_INITIALIZED)
-    (asserts! (not (var-get emergency-pause)) ERR_UNAUTHORIZED)
+    (asserts! (not (var-get emergency-pause)) ERR_CONTRACT_PAUSED)
     (asserts! (> amount u0) ERR_INVALID_AMOUNT)
     (asserts! (<= amount total-available) ERR_INSUFFICIENT_BALANCE)
 

--- a/contracts/yield-aggregator.clar
+++ b/contracts/yield-aggregator.clar
@@ -110,6 +110,7 @@
     (total-available (+ user-deposit user-yield))
   )
     (asserts! (var-get contract-initialized) ERR_NOT_INITIALIZED)
+    (asserts! (not (var-get emergency-pause)) ERR_UNAUTHORIZED)
     (asserts! (> amount u0) ERR_INVALID_AMOUNT)
     (asserts! (<= amount total-available) ERR_INSUFFICIENT_BALANCE)
 

--- a/tests/yield-aggregator.test.ts
+++ b/tests/yield-aggregator.test.ts
@@ -118,6 +118,33 @@ describe("Aureus Protocol - Yield Aggregator Tests", () => {
       simnet.callPublicFn("yield-aggregator", "deposit-sbtc", [Cl.uint(100_000), mockSbtc], bob);
     });
 
+    it("prevents withdrawals when contract is paused", () => {
+      simnet.callPublicFn("yield-aggregator", "set-emergency-pause", [Cl.bool(true)], deployer);
+
+      const withdrawResult = simnet.callPublicFn(
+        "yield-aggregator",
+        "withdraw-sbtc",
+        [Cl.uint(50_000), mockSbtc],
+        alice
+      );
+
+      expect(withdrawResult.result).toStrictEqual(Cl.error(Cl.uint(100))); // ERR_UNAUTHORIZED
+    });
+
+    it("allows withdrawals after unpause", () => {
+      simnet.callPublicFn("yield-aggregator", "set-emergency-pause", [Cl.bool(true)], deployer);
+      simnet.callPublicFn("yield-aggregator", "set-emergency-pause", [Cl.bool(false)], deployer);
+
+      const withdrawResult = simnet.callPublicFn(
+        "yield-aggregator",
+        "withdraw-sbtc",
+        [Cl.uint(50_000), mockSbtc],
+        alice
+      );
+
+      expect(withdrawResult.result).toStrictEqual(Cl.ok(Cl.bool(true)));
+    });
+
     it("allows users to withdraw deposited tokens", () => {
       const withdrawAmount = 50_000;
       

--- a/tests/yield-aggregator.test.ts
+++ b/tests/yield-aggregator.test.ts
@@ -64,15 +64,15 @@ describe("Aureus Protocol - Yield Aggregator Tests", () => {
     it("prevents deposits when contract is paused", () => {
       // Pause the contract
       simnet.callPublicFn("yield-aggregator", "set-emergency-pause", [Cl.bool(true)], deployer);
-      
+
       const depositResult = simnet.callPublicFn(
-        "yield-aggregator", 
-        "deposit-sbtc", 
-        [Cl.uint(100_000), mockSbtc], 
+        "yield-aggregator",
+        "deposit-sbtc",
+        [Cl.uint(100_000), mockSbtc],
         alice
       );
-      
-      expect(depositResult.result).toStrictEqual(Cl.error(Cl.uint(100))); // ERR_UNAUTHORIZED
+
+      expect(depositResult.result).toStrictEqual(Cl.error(Cl.uint(108))); // ERR_CONTRACT_PAUSED
     });
 
     it("prevents zero amount deposits", () => {
@@ -128,7 +128,7 @@ describe("Aureus Protocol - Yield Aggregator Tests", () => {
         alice
       );
 
-      expect(withdrawResult.result).toStrictEqual(Cl.error(Cl.uint(100))); // ERR_UNAUTHORIZED
+      expect(withdrawResult.result).toStrictEqual(Cl.error(Cl.uint(108))); // ERR_CONTRACT_PAUSED
     });
 
     it("allows withdrawals after unpause", () => {


### PR DESCRIPTION
Adds emergency pause check to withdraw-sbtc to close security hole. Also adds ERR_CONTRACT_PAUSED error code and updates tests.