### PR TITLE
fix: recalculate tier on withdrawal

### DIFF
--- a/contracts/yield-aggregator.clar
+++ b/contracts/yield-aggregator.clar
@@ -119,18 +119,23 @@
     (match (as-contract (contract-call? token transfer amount tx-sender caller none))
       success (begin
         ;; Update user balances
-        (if (<= amount user-deposit)
-          (begin
-            (map-set user-deposits caller (- user-deposit amount))
-            (map-set user-yield-earned caller user-yield))
-          (begin
-            (map-set user-deposits caller u0)
-            (map-set user-yield-earned caller (- user-yield (- amount user-deposit))))
+        (let ((new-deposit
+          (if (<= amount user-deposit)
+            (begin
+              (map-set user-yield-earned caller user-yield)
+              (- user-deposit amount))
+            (begin
+              (map-set user-yield-earned caller (- user-yield (- amount user-deposit)))
+              u0)
+          )))
+          (map-set user-deposits caller new-deposit)
+          ;; Recalculate and update user tier based on new deposit
+          (map-set user-tier caller (calculate-tier new-deposit))
+          ;; Update total deposits
+          (var-set total-deposits (- (var-get total-deposits) (min amount user-deposit)))
+          (print {event: "withdrawal", user: caller, amount: amount, new-tier: (calculate-tier new-deposit)})
+          (ok true)
         )
-        ;; Update total deposits
-        (var-set total-deposits (- (var-get total-deposits) (min amount user-deposit)))
-        (print {event: "withdrawal", user: caller, amount: amount})
-        (ok true)
       )
       error ERR_WITHDRAWAL_FAILED
     )

--- a/tests/yield-aggregator.test.ts
+++ b/tests/yield-aggregator.test.ts
@@ -369,6 +369,46 @@ describe("Aureus Protocol - Yield Aggregator Tests", () => {
       const cap = simnet.callReadOnlyFn("yield-aggregator", "get-max-deposit-per-user", [], deployer);
       expect(cap.result).toStrictEqual(Cl.ok(Cl.uint(500_000_000))); // 500M sats default
     });
+
+    it("tier downgrades to BRONZE after full withdrawal", () => {
+      // Deposit to reach SILVER tier (10M sats)
+      simnet.callPublicFn("mock-sbtc", "mint", [Cl.uint(10_000_000), Cl.principal(alice)], deployer);
+      simnet.callPublicFn("yield-aggregator", "deposit-sbtc", [Cl.uint(10_000_000), mockSbtc], alice);
+
+      const tierBefore = simnet.callReadOnlyFn("yield-aggregator", "get-user-tier", [Cl.principal(alice)], deployer);
+      expect(tierBefore.result).toStrictEqual(Cl.ok(Cl.uint(1))); // SILVER
+
+      // Withdraw all
+      simnet.callPublicFn("yield-aggregator", "withdraw-sbtc", [Cl.uint(10_000_000), mockSbtc], alice);
+
+      const tierAfter = simnet.callReadOnlyFn("yield-aggregator", "get-user-tier", [Cl.principal(alice)], deployer);
+      expect(tierAfter.result).toStrictEqual(Cl.ok(Cl.uint(0))); // BRONZE
+    });
+
+    it("tier stays SILVER after partial withdrawal above threshold", () => {
+      simnet.callPublicFn("mock-sbtc", "mint", [Cl.uint(20_000_000), Cl.principal(alice)], deployer);
+      simnet.callPublicFn("yield-aggregator", "deposit-sbtc", [Cl.uint(20_000_000), mockSbtc], alice);
+
+      // Withdraw 5M, still above silver threshold (10M)
+      simnet.callPublicFn("yield-aggregator", "withdraw-sbtc", [Cl.uint(5_000_000), mockSbtc], alice);
+
+      const tierAfter = simnet.callReadOnlyFn("yield-aggregator", "get-user-tier", [Cl.principal(alice)], deployer);
+      expect(tierAfter.result).toStrictEqual(Cl.ok(Cl.uint(1))); // Still SILVER
+    });
+
+    it("tier downgrades from GOLD to SILVER after large withdrawal", () => {
+      simnet.callPublicFn("mock-sbtc", "mint", [Cl.uint(50_000_000), Cl.principal(alice)], deployer);
+      simnet.callPublicFn("yield-aggregator", "deposit-sbtc", [Cl.uint(50_000_000), mockSbtc], alice);
+
+      const tierBefore = simnet.callReadOnlyFn("yield-aggregator", "get-user-tier", [Cl.principal(alice)], deployer);
+      expect(tierBefore.result).toStrictEqual(Cl.ok(Cl.uint(2))); // GOLD
+
+      // Withdraw 41M, leaving 9M (below gold threshold 50M, below silver only at 10M but 9M < 10M so BRONZE)
+      simnet.callPublicFn("yield-aggregator", "withdraw-sbtc", [Cl.uint(41_000_000), mockSbtc], alice);
+
+      const tierAfter = simnet.callReadOnlyFn("yield-aggregator", "get-user-tier", [Cl.principal(alice)], deployer);
+      expect(tierAfter.result).toStrictEqual(Cl.ok(Cl.uint(0))); // BRONZE (9M < 10M silver threshold)
+    });
   });
 
   describe("Read-Only Functions", () => {


### PR DESCRIPTION
Tier was not being recalculated after withdrawal. Now calls calculate-tier after updating user deposits and stores updated tier in user-tier map. Tests added.