### PR TITLE
fix: adapter error code reuse

### DIFF
--- a/contracts/protocol-adapter.clar
+++ b/contracts/protocol-adapter.clar
@@ -38,7 +38,6 @@
 (define-data-var active-protocol uint PROTOCOL_ZEST)
 (define-data-var total-protocols uint u4)
 (define-data-var adapter-paused bool false)
-(define-data-var rebalancing-threshold uint u500) ;; 5% threshold
 (define-data-var adapter-initialized bool false)
 
 ;; data maps

--- a/contracts/protocol-adapter.clar
+++ b/contracts/protocol-adapter.clar
@@ -26,6 +26,7 @@
 (define-constant ERR_WITHDRAWAL_FAILED (err u205))
 (define-constant ERR_INSUFFICIENT_LIQUIDITY (err u206))
 (define-constant ERR_PROTOCOL_PAUSED (err u207))
+(define-constant ERR_ALREADY_INITIALIZED (err u208))
 
 ;; Protocol identifiers
 (define-constant PROTOCOL_ZEST u1)

--- a/contracts/protocol-adapter.clar
+++ b/contracts/protocol-adapter.clar
@@ -59,7 +59,7 @@
 (define-public (initialize-adapter)
   (begin
     (asserts! (is-eq tx-sender CONTRACT_OWNER) ERR_UNAUTHORIZED)
-    (asserts! (not (var-get adapter-initialized)) ERR_UNAUTHORIZED)
+    (asserts! (not (var-get adapter-initialized)) ERR_ALREADY_INITIALIZED)
 
     ;; Initialize default protocols
     (map-set protocol-info PROTOCOL_ZEST {

--- a/tests/protocol-adapter.test.ts
+++ b/tests/protocol-adapter.test.ts
@@ -38,9 +38,9 @@ describe("Aureus Protocol - Protocol Adapter Tests", () => {
     });
 
     it("prevents double initialization of adapter", () => {
-      // beforeEach already initialized, second call should fail
+      // beforeEach already initialized, second call should fail with ERR_ALREADY_INITIALIZED
       const initResult = simnet.callPublicFn("protocol-adapter", "initialize-adapter", [], deployer);
-      expect(initResult.result).toStrictEqual(Cl.error(Cl.uint(200))); // ERR_UNAUTHORIZED (already initialized)
+      expect(initResult.result).toStrictEqual(Cl.error(Cl.uint(208))); // ERR_ALREADY_INITIALIZED
     });
 
     it("prevents non-deployer from initializing adapter", () => {


### PR DESCRIPTION
Fixes ERR_UNAUTHORIZED reuse in initialize-adapter. Adds ERR_ALREADY_INITIALIZED u208 and removes unused rebalancing-threshold var.