### PR TITLE
feat: withdrawal history tracking

### DIFF
--- a/contracts/yield-aggregator.clar
+++ b/contracts/yield-aggregator.clar
@@ -301,6 +301,14 @@
 (define-read-only (get-minimum-deposit)
   (ok (var-get min-deposit-amount)))
 
+;; Get withdrawal record by ID
+(define-read-only (get-withdrawal-record (id uint))
+  (ok (map-get? withdrawal-history id)))
+
+;; Get total withdrawal count
+(define-read-only (get-withdrawal-count)
+  (ok (var-get withdrawal-counter)))
+
 ;; Get user share of total deposits as basis points (100 = 1%)
 (define-read-only (get-user-share (user principal))
   (let (

--- a/contracts/yield-aggregator.clar
+++ b/contracts/yield-aggregator.clar
@@ -33,11 +33,13 @@
 (define-data-var total-deposits uint u0)
 (define-data-var total-yield-earned uint u0)
 (define-data-var emergency-pause bool false)
+(define-data-var withdrawal-counter uint u0)
 
 ;; data maps
 (define-map user-deposits principal uint)
 (define-map user-yield-earned principal uint)
 (define-map deposit-history principal (list 100 {amount: uint, timestamp: uint, block-height: uint}))
+(define-map withdrawal-history uint {user: principal, amount: uint, block-height: uint})
 
 ;; Deposit tiers for yield bonus
 (define-constant TIER_BRONZE u0)

--- a/contracts/yield-aggregator.clar
+++ b/contracts/yield-aggregator.clar
@@ -137,6 +137,12 @@
           (map-set user-tier caller (calculate-tier new-deposit))
           ;; Update total deposits
           (var-set total-deposits (- (var-get total-deposits) (min amount user-deposit)))
+          ;; Record withdrawal in history
+          (let ((withdrawal-id (var-get withdrawal-counter)))
+            (map-set withdrawal-history withdrawal-id
+              {user: caller, amount: amount, block-height: stacks-block-height})
+            (var-set withdrawal-counter (+ withdrawal-id u1))
+          )
           (print {event: "withdrawal", user: caller, amount: amount, new-tier: (calculate-tier new-deposit)})
           (ok true)
         )

--- a/tests/yield-aggregator.test.ts
+++ b/tests/yield-aggregator.test.ts
@@ -531,4 +531,39 @@ describe("Aureus Protocol - Yield Aggregator Tests", () => {
       expect(setResult.result).toStrictEqual(Cl.error(Cl.uint(100)));
     });
   });
+
+  describe("Withdrawal History", () => {
+    beforeEach(() => {
+      simnet.callPublicFn("mock-sbtc", "mint", [Cl.uint(5_000_000), Cl.principal(alice)], deployer);
+      simnet.callPublicFn("yield-aggregator", "deposit-sbtc", [Cl.uint(5_000_000), mockSbtc], alice);
+    });
+
+    it("withdrawal count starts at zero before any withdrawal", () => {
+      const count = simnet.callReadOnlyFn("yield-aggregator", "get-withdrawal-count", [], deployer);
+      expect(count.result).toStrictEqual(Cl.ok(Cl.uint(0)));
+    });
+
+    it("records withdrawal in history after withdraw", () => {
+      simnet.callPublicFn("yield-aggregator", "withdraw-sbtc", [Cl.uint(1_000_000), mockSbtc], alice);
+
+      const count = simnet.callReadOnlyFn("yield-aggregator", "get-withdrawal-count", [], deployer);
+      expect(count.result).toStrictEqual(Cl.ok(Cl.uint(1)));
+
+      const record = simnet.callReadOnlyFn("yield-aggregator", "get-withdrawal-record", [Cl.uint(0)], deployer);
+      expect(record.result).toBeOk();
+    });
+
+    it("increments counter for each withdrawal", () => {
+      simnet.callPublicFn("yield-aggregator", "withdraw-sbtc", [Cl.uint(1_000_000), mockSbtc], alice);
+      simnet.callPublicFn("yield-aggregator", "withdraw-sbtc", [Cl.uint(1_000_000), mockSbtc], alice);
+
+      const count = simnet.callReadOnlyFn("yield-aggregator", "get-withdrawal-count", [], deployer);
+      expect(count.result).toStrictEqual(Cl.ok(Cl.uint(2)));
+    });
+
+    it("returns none for non-existent withdrawal record", () => {
+      const record = simnet.callReadOnlyFn("yield-aggregator", "get-withdrawal-record", [Cl.uint(99)], deployer);
+      expect(record.result).toStrictEqual(Cl.ok(Cl.none()));
+    });
+  });
 });


### PR DESCRIPTION
Adds withdrawal-counter data var, withdrawal-history map, records each withdrawal, and exposes get-withdrawal-record and get-withdrawal-count read-only functions.