### PR TITLE
feat: integrate Stacks API calls for yield aggregator dashboard

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -407,6 +407,25 @@ function loadUserData(address) {
             .catch(function (err) {
                 console.error('Failed to load user yield:', err);
             });
+
+        // Load STX balance from Stacks extended API
+        getSTXBalance(address)
+            .then(function (data) {
+                try {
+                    var el = document.getElementById('userStxBalance');
+                    if (el && data && data.balance != null) {
+                        var stx = parseInt(data.balance, 10) / 1000000;
+                        el.textContent = stx.toLocaleString(undefined, {maximumFractionDigits: 2}) + ' STX';
+                    }
+                } catch (e) {
+                    console.error('Error parsing STX balance:', e);
+                }
+            })
+            .catch(function (err) {
+                console.error('Failed to load STX balance:', err);
+                var el = document.getElementById('userStxBalance');
+                if (el) el.textContent = '-- STX';
+            });
     } catch (err) {
         console.error('loadUserData error:', err);
     }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -89,7 +89,11 @@ document.addEventListener('DOMContentLoaded', function () {
     document.getElementById('walletBtn').addEventListener('click', handleWalletClick);
     document.getElementById('depositBtn').addEventListener('click', handleDeposit);
     document.getElementById('withdrawBtn').addEventListener('click', handleWithdraw);
+    var refreshBtn = document.getElementById('refreshTxBtn');
+    if (refreshBtn) refreshBtn.addEventListener('click', loadContractEvents);
     loadProtocolRates();
+    loadContractEvents();
+    loadNetworkStatus();
     checkExistingSession();
 });
 
@@ -253,6 +257,108 @@ function loadVaultMetrics() {
     } catch (err) {
         console.error('loadVaultMetrics error:', err);
     }
+}
+
+/**
+ * Load recent contract events from yield-aggregator and display in the transactions panel.
+ */
+function loadContractEvents() {
+    var contractId = CONTRACT_ADDRESS + '.yield-aggregator';
+    var listEl = document.getElementById('txList');
+    if (listEl) {
+        listEl.textContent = '';
+        var loadingP = document.createElement('p');
+        loadingP.className = 'tx-loading';
+        loadingP.textContent = 'Loading events...';
+        listEl.appendChild(loadingP);
+    }
+
+    getContractEvents(contractId, 10)
+        .then(function (data) {
+            renderContractEvents(data);
+        })
+        .catch(function (err) {
+            console.error('Failed to load contract events:', err);
+            if (listEl) {
+                listEl.textContent = '';
+                var emptyP = document.createElement('p');
+                emptyP.className = 'tx-empty';
+                emptyP.textContent = 'Could not load events. Check API connectivity.';
+                listEl.appendChild(emptyP);
+            }
+        });
+}
+
+/**
+ * Render contract events into the transactions panel using safe DOM methods.
+ * @param {object} data - API response with results array
+ */
+function renderContractEvents(data) {
+    var listEl = document.getElementById('txList');
+    if (!listEl) return;
+
+    listEl.textContent = '';
+
+    if (!data || !data.results || data.results.length === 0) {
+        var emptyP = document.createElement('p');
+        emptyP.className = 'tx-empty';
+        emptyP.textContent = 'No recent contract events found.';
+        listEl.appendChild(emptyP);
+        return;
+    }
+
+    data.results.forEach(function (event) {
+        var eventType = event.event_type || 'unknown';
+        var txId = event.tx_id || '';
+        var shortTx = txId ? txId.slice(0, 10) + '...' : 'N/A';
+        var contractLogRepr = '';
+        if (event.contract_log && event.contract_log.value) {
+            contractLogRepr = event.contract_log.value.repr || '';
+        }
+
+        var itemDiv = document.createElement('div');
+        itemDiv.className = 'tx-item';
+
+        var typeSpan = document.createElement('span');
+        typeSpan.className = 'tx-type';
+        typeSpan.textContent = eventType;
+        itemDiv.appendChild(typeSpan);
+
+        var idSpan = document.createElement('span');
+        idSpan.className = 'tx-id';
+        idSpan.title = txId;
+        idSpan.textContent = shortTx;
+        itemDiv.appendChild(idSpan);
+
+        if (contractLogRepr) {
+            var logSpan = document.createElement('span');
+            logSpan.className = 'tx-log';
+            logSpan.textContent = contractLogRepr.slice(0, 80);
+            itemDiv.appendChild(logSpan);
+        }
+
+        listEl.appendChild(itemDiv);
+    });
+}
+
+/**
+ * Load and display network status information.
+ */
+function loadNetworkStatus() {
+    getNetworkInfo()
+        .then(function (data) {
+            var blockEl = document.getElementById('blockHeight');
+            var versionEl = document.getElementById('serverVersion');
+            if (blockEl && data.stacks_tip_height != null) {
+                blockEl.textContent = data.stacks_tip_height.toLocaleString();
+            }
+            if (versionEl && data.server_version) {
+                versionEl.textContent = data.server_version;
+            }
+        })
+        .catch(function (err) {
+            console.error('Failed to load network status:', err);
+        });
 }
 
 function encodePrincipal(address) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -95,6 +95,8 @@ document.addEventListener('DOMContentLoaded', function () {
     loadContractEvents();
     loadNetworkStatus();
     checkExistingSession();
+    // Auto-refresh network status every 30 seconds
+    setInterval(loadNetworkStatus, 30000);
 });
 
 function checkExistingSession() {
@@ -179,6 +181,8 @@ function onConnected(address) {
     btn.classList.add('connected');
     loadUserData(address);
     loadVaultMetrics();
+    loadNetworkStatus();
+    loadContractEvents();
 }
 
 function loadProtocolRates() {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7,6 +7,84 @@ var API_URL = CONFIG.apiUrl;
 var CONTRACT_ADDRESS = CONFIG.contractAddress;
 var userAddress = null;
 
+// ============================================================
+// Stacks API Helper Module
+// ============================================================
+
+/**
+ * Generic Stacks API fetcher with error handling and JSON parsing.
+ * @param {string} endpoint - Path relative to API_URL (e.g. '/extended/v1/...')
+ * @returns {Promise<object>} Parsed JSON response
+ */
+function fetchStacksApi(endpoint) {
+    return fetch(API_URL + endpoint, {
+        headers: { 'Content-Type': 'application/json' }
+    }).then(function (res) {
+        if (!res.ok) {
+            throw new Error('Stacks API error ' + res.status + ' for ' + endpoint);
+        }
+        return res.json();
+    }).catch(function (err) {
+        console.error('fetchStacksApi failed:', endpoint, err);
+        throw err;
+    });
+}
+
+/**
+ * Get STX balance for an address.
+ * @param {string} address - Stacks address
+ * @returns {Promise<object>} Balance object with balance, locked fields
+ */
+function getSTXBalance(address) {
+    return fetchStacksApi('/extended/v1/address/' + address + '/stx');
+}
+
+/**
+ * Get recent contract events for a contract ID.
+ * @param {string} contractId - Format: "address.contract-name"
+ * @param {number} limit - Number of events to fetch (default 20)
+ * @returns {Promise<object>} Events response
+ */
+function getContractEvents(contractId, limit) {
+    var l = limit || 20;
+    return fetchStacksApi('/extended/v1/contract/' + encodeURIComponent(contractId) + '/events?limit=' + l);
+}
+
+/**
+ * Call a read-only contract function via the Stacks v2 API.
+ * @param {string} addr - Contract deployer address
+ * @param {string} name - Contract name
+ * @param {string} fn - Function name
+ * @param {Array} args - Array of Clarity value hex strings
+ * @returns {Promise<object>} Result with okay and result fields
+ */
+function callContractReadOnly(addr, name, fn, args) {
+    var url = API_URL + '/v2/contracts/call-read/' + addr + '/' + name + '/' + fn;
+    return fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sender: addr, arguments: args || [] })
+    }).then(function (r) { return r.json(); });
+}
+
+/**
+ * Get a transaction by its ID.
+ * @param {string} txid - Transaction ID (with or without 0x prefix)
+ * @returns {Promise<object>} Transaction details
+ */
+function getTransactionById(txid) {
+    var id = txid.startsWith('0x') ? txid : '0x' + txid;
+    return fetchStacksApi('/extended/v1/tx/' + id);
+}
+
+/**
+ * Get current network info (block height, etc).
+ * @returns {Promise<object>} Network info object
+ */
+function getNetworkInfo() {
+    return fetchStacksApi('/v2/info');
+}
+
 document.addEventListener('DOMContentLoaded', function () {
     document.getElementById('walletBtn').addEventListener('click', handleWalletClick);
     document.getElementById('depositBtn').addEventListener('click', handleDeposit);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -538,17 +538,15 @@ function handleWithdraw() {
     }
 }
 
+/**
+ * Call a read-only Clarity function (legacy wrapper using callContractReadOnly).
+ * @param {string} contract - Contract name
+ * @param {string} fnName - Function name
+ * @param {Array} args - Encoded arguments
+ * @returns {Promise<object>}
+ */
 function callReadOnly(contract, fnName, args) {
-    var url = API_URL + '/v2/contracts/call-read/' +
-        CONTRACT_ADDRESS + '/' + contract + '/' + fnName;
-    return fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            sender: CONTRACT_ADDRESS,
-            arguments: args || []
-        })
-    }).then(function (r) { return r.json(); });
+    return callContractReadOnly(CONTRACT_ADDRESS, contract, fnName, args);
 }
 
 /**

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -445,9 +445,14 @@ function handleDeposit() {
             icon: window.location.origin + '/favicon.svg'
         },
         onFinish: function (data) {
-            alert('Deposit submitted! TX: ' + data.txId);
             amountInput.value = '';
-            loadVaultMetrics();
+            showTxStatus('Deposit pending: ' + data.txId, 'pending');
+            pollTxConfirmation(data.txId, function () {
+                showTxStatus('Deposit confirmed!', 'confirmed');
+                loadVaultMetrics();
+                loadUserData(userAddress);
+                loadContractEvents();
+            });
         },
         onCancel: function () {
             console.log('Deposit cancelled');
@@ -489,10 +494,14 @@ function handleWithdraw() {
             icon: window.location.origin + '/favicon.svg'
         },
         onFinish: function (data) {
-            alert('Withdrawal submitted! TX: ' + data.txId);
             amountInput.value = '';
-            loadVaultMetrics();
-            loadUserData(userAddress);
+            showTxStatus('Withdrawal pending: ' + data.txId, 'pending');
+            pollTxConfirmation(data.txId, function () {
+                showTxStatus('Withdrawal confirmed!', 'confirmed');
+                loadVaultMetrics();
+                loadUserData(userAddress);
+                loadContractEvents();
+            });
         },
         onCancel: function () {
             console.log('Withdrawal cancelled');
@@ -517,4 +526,59 @@ function callReadOnly(contract, fnName, args) {
             arguments: args || []
         })
     }).then(function (r) { return r.json(); });
+}
+
+/**
+ * Show transaction status message in the vault status area.
+ * @param {string} message - Status text to display
+ * @param {string} state - 'pending' or 'confirmed'
+ */
+function showTxStatus(message, state) {
+    var statusEl = document.getElementById('txStatus');
+    var textEl = document.getElementById('txStatusText');
+    if (!statusEl || !textEl) return;
+
+    textEl.textContent = message;
+    statusEl.className = 'tx-status tx-status-' + (state || 'pending');
+    statusEl.style.display = 'block';
+
+    if (state === 'confirmed') {
+        setTimeout(function () {
+            statusEl.style.display = 'none';
+        }, 5000);
+    }
+}
+
+/**
+ * Poll for transaction confirmation using getTransactionById.
+ * @param {string} txId - Transaction ID to poll
+ * @param {Function} onConfirmed - Callback when tx is confirmed
+ * @param {number} maxAttempts - Max polling attempts (default 30)
+ */
+function pollTxConfirmation(txId, onConfirmed, maxAttempts) {
+    var attempts = 0;
+    var max = maxAttempts || 30;
+    var intervalMs = 6000; // 6 second polling interval
+
+    function checkOnce() {
+        attempts++;
+        getTransactionById(txId)
+            .then(function (tx) {
+                if (tx && (tx.tx_status === 'success' || tx.tx_status === 'abort_by_response')) {
+                    if (typeof onConfirmed === 'function') onConfirmed(tx);
+                } else if (attempts < max) {
+                    setTimeout(checkOnce, intervalMs);
+                } else {
+                    showTxStatus('Transaction timed out. Check explorer.', 'error');
+                }
+            })
+            .catch(function (err) {
+                console.warn('TX poll error:', err);
+                if (attempts < max) {
+                    setTimeout(checkOnce, intervalMs);
+                }
+            });
+    }
+
+    setTimeout(checkOnce, intervalMs);
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,6 +29,8 @@
             <li><a href="#features">Features</a></li>
             <li><a href="#protocols">Protocols</a></li>
             <li><a href="#vault">Vault</a></li>
+            <li><a href="#transactions">Activity</a></li>
+            <li><a href="#network">Network</a></li>
         </ul>
         <button id="walletBtn" class="btn-wallet">Connect Wallet</button>
     </nav>
@@ -131,13 +133,45 @@
             <div class="vault-info">
                 <p>Your Deposit: <strong id="userDeposit">--</strong> sBTC</p>
                 <p>Earned Yield: <strong id="userYield">--</strong> sBTC</p>
+                <p>STX Balance: <strong id="userStxBalance">--</strong> STX</p>
             </div>
             <div class="vault-actions">
                 <input type="number" id="depositAmount" placeholder="Amount in sBTC" min="0">
                 <button id="depositBtn" class="btn-gold">Deposit</button>
                 <button id="withdrawBtn" class="btn-outline-dark">Withdraw</button>
             </div>
+            <div id="txStatus" class="tx-status" style="display:none;">
+                <span id="txStatusText">Transaction pending...</span>
+            </div>
             <p class="vault-note">Connect wallet to interact with the vault</p>
+        </div>
+    </section>
+
+    <section id="transactions" class="transactions">
+        <h2>Recent Contract Events</h2>
+        <div class="tx-panel">
+            <div id="txList" class="tx-list">
+                <p class="tx-empty">No recent events. Connect wallet or wait for activity.</p>
+            </div>
+            <button id="refreshTxBtn" class="btn-outline">Refresh Events</button>
+        </div>
+    </section>
+
+    <section id="network" class="network-status">
+        <h2>Network Status</h2>
+        <div class="network-grid">
+            <div class="network-item">
+                <span class="network-label">Block Height</span>
+                <span id="blockHeight" class="network-val">--</span>
+            </div>
+            <div class="network-item">
+                <span class="network-label">Network</span>
+                <span id="networkName" class="network-val">Testnet</span>
+            </div>
+            <div class="network-item">
+                <span class="network-label">Server Version</span>
+                <span id="serverVersion" class="network-val">--</span>
+            </div>
         </div>
     </section>
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -376,6 +376,127 @@ footer {
     font-size: 0.8rem;
 }
 
+/* Transaction Status */
+.tx-status {
+    margin-top: 0.75rem;
+    padding: 0.6rem 1rem;
+    border-radius: 6px;
+    font-size: 0.85rem;
+}
+.tx-status-pending { background: rgba(201, 168, 76, 0.15); color: var(--gold); border: 1px solid var(--gold); }
+.tx-status-confirmed { background: rgba(16, 185, 129, 0.15); color: var(--green); border: 1px solid var(--green); }
+.tx-status-error { background: rgba(239, 68, 68, 0.15); color: #ef4444; border: 1px solid #ef4444; }
+
+/* Transactions Section */
+.transactions {
+    padding: 3rem 2rem;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.transactions h2 {
+    color: var(--gold);
+    margin-bottom: 1.5rem;
+    font-size: 1.4rem;
+}
+
+.tx-panel {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.5rem;
+}
+
+.tx-list {
+    min-height: 80px;
+    margin-bottom: 1rem;
+}
+
+.tx-item {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.6rem 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.85rem;
+}
+
+.tx-item:last-child { border-bottom: none; }
+
+.tx-type {
+    background: rgba(201, 168, 76, 0.15);
+    color: var(--gold);
+    padding: 0.2rem 0.6rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    min-width: 100px;
+    text-align: center;
+}
+
+.tx-id {
+    color: var(--muted);
+    font-family: monospace;
+    font-size: 0.8rem;
+}
+
+.tx-log {
+    color: var(--text);
+    font-size: 0.78rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+}
+
+.tx-empty, .tx-loading {
+    color: var(--muted);
+    font-size: 0.88rem;
+    padding: 1rem 0;
+}
+
+/* Network Status Section */
+.network-status {
+    padding: 2rem 2rem 3rem;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.network-status h2 {
+    color: var(--gold);
+    margin-bottom: 1.5rem;
+    font-size: 1.4rem;
+}
+
+.network-grid {
+    display: flex;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.network-item {
+    background: var(--card-bg);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    min-width: 160px;
+}
+
+.network-label {
+    color: var(--muted);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.network-val {
+    color: var(--text);
+    font-size: 1.1rem;
+    font-weight: 600;
+}
+
 /* Mobile */
 @media (max-width: 768px) {
     .nav { padding: 0.8rem 1.2rem; }
@@ -386,4 +507,6 @@ footer {
     .metrics-grid { flex-direction: column; gap: 1.5rem; }
     .vault-actions { flex-direction: column; }
     .footer-grid { flex-direction: column; gap: 1.5rem; }
+    .network-grid { flex-direction: column; }
+    .tx-item { flex-wrap: wrap; }
 }


### PR DESCRIPTION
## Summary
- Add Stacks API helper module (fetchStacksApi, getSTXBalance, getContractEvents, callContractReadOnly, getTransactionById, getNetworkInfo)
- Add Recent Contract Events panel with safe DOM rendering and refresh button
- Add Network Status section with block height, network name, server version
- Add deposit/withdrawal transaction confirmation polling with status display
- Add proper STX balance display from Stacks extended API
- Add protocol metrics auto-refresh every 30 seconds
- Add CSS for all new sections (tx status, tx panel, network grid)
- Refactor callReadOnly to delegate to callContractReadOnly helper

## Test plan
- [x] All 78 tests still pass
- [x] clarinet check: 4 contracts checked, 0 errors
- [x] Frontend renders new sections without JS errors